### PR TITLE
Fix cmux socket discovery — stop overriding CMUX_SOCKET_PATH with wro…

### DIFF
--- a/launchd/dev.perch.plist.template
+++ b/launchd/dev.perch.plist.template
@@ -24,8 +24,6 @@
     <string>{{HOME}}</string>
     <key>PATH</key>
     <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
-    <key>CMUX_SOCKET_PATH</key>
-    <string>{{HOME}}/Library/Application Support/cmux/cmux.sock</string>
   </dict>
   <key>ThrottleInterval</key>
   <integer>5</integer>

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -27,15 +27,9 @@ const CMUX_BIN =
   process.env.CMUX_BIN ??
   '/Applications/cmux.app/Contents/Resources/bin/cmux'
 
-const CMUX_SOCKET =
-  process.env.CMUX_SOCKET_PATH ??
-  join(homedir(), 'Library', 'Application Support', 'cmux', 'cmux.sock')
-
 async function validateCmuxConnection(): Promise<boolean> {
   try {
-    await execa(CMUX_BIN, ['ping'], {
-      env: { ...process.env, CMUX_SOCKET_PATH: CMUX_SOCKET },
-    })
+    await execa(CMUX_BIN, ['ping'])
     return true
   } catch {
     return false

--- a/packages/daemon/src/adapters/cmux.test.ts
+++ b/packages/daemon/src/adapters/cmux.test.ts
@@ -31,7 +31,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['ping'],
-        expect.objectContaining({ env: expect.any(Object) }),
       )
     })
 
@@ -124,7 +123,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:5', '--lines', '30'],
-        expect.any(Object),
+
       )
     })
 
@@ -134,7 +133,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:5', '--lines', '50'],
-        expect.any(Object),
+
       )
     })
 
@@ -144,7 +143,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:3', '--lines', '50'],
-        expect.any(Object),
+
       )
     })
 
@@ -154,7 +153,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:7', '--lines', '50'],
-        expect.any(Object),
+
       )
     })
   })
@@ -171,12 +170,12 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send', '--surface', 'surface:5', 'echo hello'],
-        expect.any(Object),
+
       )
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send-key', '--surface', 'surface:5', 'enter'],
-        expect.any(Object),
+
       )
     })
   })
@@ -204,7 +203,7 @@ describe('CmuxAdapter', () => {
         expect(mockExeca).toHaveBeenCalledWith(
           expect.stringContaining('cmux'),
           ['send-key', '--surface', 'surface:5', expected],
-          expect.any(Object),
+  
         )
       }
     })
@@ -215,7 +214,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send-key', '--surface', 'surface:5', 'f5'],
-        expect.any(Object),
+
       )
     })
   })
@@ -231,7 +230,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-workspace', '--name', 'my-new'],
-        expect.any(Object),
+
       )
       expect(session.name).toBe('my-new')
     })
@@ -245,7 +244,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-workspace', '--name', 'dev', '--cwd', '/home/user', '--command', 'vim'],
-        expect.any(Object),
+
       )
     })
 
@@ -265,7 +264,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['workspace-action', '--action', 'rename', '--workspace', 'workspace:1', '--title', 'new-name'],
-        expect.any(Object),
+
       )
     })
   })
@@ -277,7 +276,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['close-workspace', '--workspace', 'workspace:1'],
-        expect.any(Object),
+
       )
     })
   })
@@ -289,7 +288,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-split', 'right', '--workspace', 'workspace:1', '--surface', 'surface:5'],
-        expect.any(Object),
+
       )
       expect(pane.id).toBe('cmux:workspace:1:surface:20')
       expect(pane.active).toBe(true)
@@ -309,7 +308,7 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['focus-surface', '--surface', 'surface:5'],
-        expect.any(Object),
+
       )
     })
 

--- a/packages/daemon/src/adapters/cmux.test.ts
+++ b/packages/daemon/src/adapters/cmux.test.ts
@@ -123,7 +123,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:5', '--lines', '30'],
-
       )
     })
 
@@ -133,7 +132,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:5', '--lines', '50'],
-
       )
     })
 
@@ -143,7 +141,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:3', '--lines', '50'],
-
       )
     })
 
@@ -153,7 +150,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['capture-pane', '--surface', 'surface:7', '--lines', '50'],
-
       )
     })
   })
@@ -170,12 +166,10 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send', '--surface', 'surface:5', 'echo hello'],
-
       )
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send-key', '--surface', 'surface:5', 'enter'],
-
       )
     })
   })
@@ -203,7 +197,6 @@ describe('CmuxAdapter', () => {
         expect(mockExeca).toHaveBeenCalledWith(
           expect.stringContaining('cmux'),
           ['send-key', '--surface', 'surface:5', expected],
-  
         )
       }
     })
@@ -214,7 +207,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['send-key', '--surface', 'surface:5', 'f5'],
-
       )
     })
   })
@@ -230,7 +222,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-workspace', '--name', 'my-new'],
-
       )
       expect(session.name).toBe('my-new')
     })
@@ -244,7 +235,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-workspace', '--name', 'dev', '--cwd', '/home/user', '--command', 'vim'],
-
       )
     })
 
@@ -264,7 +254,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['workspace-action', '--action', 'rename', '--workspace', 'workspace:1', '--title', 'new-name'],
-
       )
     })
   })
@@ -276,7 +265,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['close-workspace', '--workspace', 'workspace:1'],
-
       )
     })
   })
@@ -288,7 +276,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['new-split', 'right', '--workspace', 'workspace:1', '--surface', 'surface:5'],
-
       )
       expect(pane.id).toBe('cmux:workspace:1:surface:20')
       expect(pane.active).toBe(true)
@@ -308,7 +295,6 @@ describe('CmuxAdapter', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         expect.stringContaining('cmux'),
         ['focus-surface', '--surface', 'surface:5'],
-
       )
     })
 

--- a/packages/daemon/src/adapters/cmux.ts
+++ b/packages/daemon/src/adapters/cmux.ts
@@ -1,20 +1,12 @@
 import { execa } from 'execa'
-import { homedir } from 'os'
-import { join } from 'path'
 import type { ITerminalAdapter, Pane, Session, Window } from './interface.js'
 
 const CMUX_BIN =
   process.env.CMUX_BIN ??
   '/Applications/cmux.app/Contents/Resources/bin/cmux'
 
-const CMUX_SOCKET =
-  process.env.CMUX_SOCKET_PATH ??
-  join(homedir(), 'Library', 'Application Support', 'cmux', 'cmux.sock')
-
 function cmux(args: string[]) {
-  return execa(CMUX_BIN, args, {
-    env: { ...process.env, CMUX_SOCKET_PATH: CMUX_SOCKET },
-  })
+  return execa(CMUX_BIN, args)
 }
 
 // Map from plugin key names to cmux send-key names


### PR DESCRIPTION
Summary

  ▎ - The cmux adapter and LaunchAgent plist hardcoded CMUX_SOCKET_PATH to ~/Library/Application Support/cmux/cmux.sock, but cmux creates its socket at /tmp/cmux.sock
  ▎ - The adapter force-injected this wrong path into every cmux CLI call, preventing the binary from using its own built-in socket discovery
  ▎ - This caused the daemon to crash-loop: Error: Socket not found at .../Library/Application Support/cmux/cmux.sock

  ▎ Fix

  ▎ Removed the hardcoded CMUX_SOCKET_PATH from the adapter, CLI setup validation, and plist template. The cmux binary already knows where its socket is — we just need to stop overriding it.

  ▎ Files changed

  ▎ - packages/daemon/src/adapters/cmux.ts — removed CMUX_SOCKET constant and env override in cmux() helper
  ▎ - packages/cli/src/commands/setup.ts — same fix for validateCmuxConnection()
  ▎ - launchd/dev.perch.plist.template — removed CMUX_SOCKET_PATH from LaunchAgent env
  ▎ - packages/daemon/src/adapters/cmux.test.ts — updated assertions to match