### PR TITLE
Match Claude panes by TTY — fix `list` dropping sessions

### DIFF
--- a/packages/daemon/src/adapters/cmux.test.ts
+++ b/packages/daemon/src/adapters/cmux.test.ts
@@ -311,4 +311,69 @@ describe('CmuxAdapter', () => {
       await expect(adapter.selectPane('cmux:workspace:1:surface:5')).resolves.toBeUndefined()
     })
   })
+
+  describe('getPaneTty', () => {
+    it('runs cmux tree scoped to the pane workspace and parses tty=', async () => {
+      mockOutput('surface surface:5 [terminal] "title" tty=ttys009')
+      const tty = await adapter.getPaneTty('cmux:workspace:1:surface:5')
+      expect(tty).toBe('ttys009')
+      expect(mockExeca).toHaveBeenCalledWith(
+        expect.stringContaining('cmux'),
+        ['tree', '--workspace', 'workspace:1'],
+      )
+    })
+
+    it('falls back to --all when pane id has no workspace component', async () => {
+      mockOutput('surface surface:5 [terminal] "title" tty=ttys009')
+      const tty = await adapter.getPaneTty('surface:5')
+      expect(tty).toBe('ttys009')
+      expect(mockExeca).toHaveBeenCalledWith(
+        expect.stringContaining('cmux'),
+        ['tree', '--all'],
+      )
+    })
+
+    it('returns null when the tree output has no tty= token for the surface', async () => {
+      mockOutput('surface surface:5 [terminal] "no tty here"')
+      const tty = await adapter.getPaneTty('cmux:workspace:1:surface:5')
+      expect(tty).toBeNull()
+    })
+
+    it('returns null when cmux tree throws', async () => {
+      mockExeca.mockRejectedValueOnce(new Error('daemon down') as never)
+      const tty = await adapter.getPaneTty('cmux:workspace:1:surface:5')
+      expect(tty).toBeNull()
+    })
+  })
+
+  describe('getPanePid', () => {
+    it('returns null when the surface has no tty', async () => {
+      mockOutput('surface surface:5 [terminal] "no tty"')
+      expect(await adapter.getPanePid('cmux:workspace:1:surface:5')).toBeNull()
+    })
+
+    it('returns the first login-shell pid on the tty', async () => {
+      mockOutput('surface surface:5 [terminal] "x" tty=ttys009')
+      mockOutput(' 12345 -/bin/zsh\n 12400 vim main.ts\n')
+      const pid = await adapter.getPanePid('cmux:workspace:1:surface:5')
+      expect(pid).toBe(12345)
+    })
+
+    it('returns null when no login shell on the tty', async () => {
+      mockOutput('surface surface:5 [terminal] "x" tty=ttys009')
+      mockOutput(' 12400 vim main.ts\n')
+      expect(await adapter.getPanePid('cmux:workspace:1:surface:5')).toBeNull()
+    })
+
+    it('returns null when cmux tree throws', async () => {
+      mockExeca.mockRejectedValueOnce(new Error('daemon down') as never)
+      expect(await adapter.getPanePid('cmux:workspace:1:surface:5')).toBeNull()
+    })
+
+    it('returns null when ps -t throws', async () => {
+      mockOutput('surface surface:5 [terminal] "x" tty=ttys009')
+      mockExeca.mockRejectedValueOnce(new Error('ps fail') as never)
+      expect(await adapter.getPanePid('cmux:workspace:1:surface:5')).toBeNull()
+    })
+  })
 })

--- a/packages/daemon/src/adapters/cmux.ts
+++ b/packages/daemon/src/adapters/cmux.ts
@@ -165,6 +165,11 @@ export class CmuxAdapter implements ITerminalAdapter {
     })
   }
 
+  async getPaneTty(paneId: string): Promise<string | null> {
+    const { workspace, surface } = this._parsePaneId(paneId)
+    return this._getSurfaceTty(workspace || undefined, surface)
+  }
+
   async getPanePid(paneId: string): Promise<number | null> {
     try {
       const { workspace, surface } = this._parsePaneId(paneId)

--- a/packages/daemon/src/adapters/interface.ts
+++ b/packages/daemon/src/adapters/interface.ts
@@ -43,6 +43,14 @@ export interface ITerminalAdapter {
    */
   getPanePid?(paneId: string): Promise<number | null>
 
+  /**
+   * Return the TTY device name (e.g. "ttys009") this pane is bound to, without
+   * the "/dev/" prefix. Used by the Claude-pane finder to match `ps` output
+   * 1:1 with panes — a TTY belongs to exactly one pane, so this avoids the
+   * fragile ancestor-PID walk that misses nested shell wrappings.
+   */
+  getPaneTty?(paneId: string): Promise<string | null>
+
   // Writing
   sendText(paneId: string, text: string): Promise<void>
   sendKey(paneId: string, key: string): Promise<void>

--- a/packages/daemon/src/adapters/tmux.test.ts
+++ b/packages/daemon/src/adapters/tmux.test.ts
@@ -204,4 +204,51 @@ describe('TmuxAdapter', () => {
       expect(pane.id).toBe('tmux:main:@0:%3')
     })
   })
+
+  describe('getPanePid', () => {
+    it('queries #{pane_pid} and parses it', async () => {
+      mockOutput('12345\n')
+      const pid = await adapter.getPanePid('tmux:main:@0:%2')
+      expect(pid).toBe(12345)
+      expect(mockExeca).toHaveBeenCalledWith('tmux', [
+        'display-message', '-t', '%2', '-p', '#{pane_pid}',
+      ])
+    })
+
+    it('returns null when pid is non-numeric', async () => {
+      mockOutput('not-a-number\n')
+      expect(await adapter.getPanePid('tmux:main:@0:%2')).toBeNull()
+    })
+
+    it('returns null when display-message throws', async () => {
+      mockExeca.mockRejectedValueOnce(new Error('no such pane') as never)
+      expect(await adapter.getPanePid('tmux:main:@0:%2')).toBeNull()
+    })
+  })
+
+  describe('getPaneTty', () => {
+    it('strips /dev/ prefix from #{pane_tty}', async () => {
+      mockOutput('/dev/ttys009\n')
+      const tty = await adapter.getPaneTty('tmux:main:@0:%2')
+      expect(tty).toBe('ttys009')
+      expect(mockExeca).toHaveBeenCalledWith('tmux', [
+        'display-message', '-t', '%2', '-p', '#{pane_tty}',
+      ])
+    })
+
+    it('returns the value unchanged when not prefixed with /dev/', async () => {
+      mockOutput('ttys009\n')
+      expect(await adapter.getPaneTty('tmux:main:@0:%2')).toBe('ttys009')
+    })
+
+    it('returns null when display-message returns blank', async () => {
+      mockOutput('')
+      expect(await adapter.getPaneTty('tmux:main:@0:%2')).toBeNull()
+    })
+
+    it('returns null when display-message throws', async () => {
+      mockExeca.mockRejectedValueOnce(new Error('no such pane') as never)
+      expect(await adapter.getPaneTty('tmux:main:@0:%2')).toBeNull()
+    })
+  })
 })

--- a/packages/daemon/src/adapters/tmux.ts
+++ b/packages/daemon/src/adapters/tmux.ts
@@ -162,6 +162,23 @@ export class TmuxAdapter implements ITerminalAdapter {
     }
   }
 
+  async getPaneTty(paneId: string): Promise<string | null> {
+    try {
+      const tmuxTarget = this._toTmuxTarget(paneId)
+      const { stdout } = await execa('tmux', [
+        'display-message',
+        '-t', tmuxTarget,
+        '-p', '#{pane_tty}',
+      ])
+      const raw = stdout.trim()
+      if (!raw) return null
+      // tmux returns full path like "/dev/ttys009"; ps -o tty= uses "ttys009"
+      return raw.replace(/^\/dev\//, '')
+    } catch {
+      return null
+    }
+  }
+
   /** Convert a perch pane id "tmux:session:window:pane" → tmux target "pane" */
   private _toTmuxTarget(paneId: string): string {
     const parts = paneId.split(':')

--- a/packages/daemon/src/transcript/claude-finder.test.ts
+++ b/packages/daemon/src/transcript/claude-finder.test.ts
@@ -6,10 +6,19 @@ vi.mock('execa', () => ({
   execa: vi.fn(),
 }))
 
-import { execa } from 'execa'
-const mockExeca = vi.mocked(execa)
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+}))
 
-function makeAdapter(sessions: Session[] = [], getPanePid?: (id: string) => Promise<number | null>): ITerminalAdapter {
+import { execa } from 'execa'
+import { access } from 'fs/promises'
+const mockExeca = vi.mocked(execa)
+const mockAccess = vi.mocked(access)
+
+function makeAdapter(
+  sessions: Session[] = [],
+  getPaneTty?: (id: string) => Promise<string | null>,
+): ITerminalAdapter {
   return {
     name: 'mock',
     isAvailable: vi.fn(),
@@ -22,64 +31,72 @@ function makeAdapter(sessions: Session[] = [], getPanePid?: (id: string) => Prom
     closeSession: vi.fn(),
     splitPane: vi.fn(),
     selectPane: vi.fn(),
-    ...(getPanePid ? { getPanePid } : {}),
+    ...(getPaneTty ? { getPaneTty } : {}),
   } as unknown as ITerminalAdapter
 }
 
-const mockSession: Session = {
-  id: '$0',
-  name: 'dev',
-  windows: [{
-    id: '@0',
-    name: 'main',
-    panes: [{
-      id: 'tmux:dev:@0:%0',
-      index: 0,
-      active: true,
-      command: 'zsh',
-      dimensions: { rows: 40, cols: 120 },
+function sessionWithPane(
+  sessionName: string,
+  paneId: string,
+  title?: string,
+): Session {
+  return {
+    id: sessionName,
+    name: sessionName,
+    windows: [{
+      id: '@0',
+      name: 'main',
+      panes: [{
+        id: paneId,
+        index: 0,
+        active: true,
+        command: 'zsh',
+        title,
+        dimensions: { rows: 40, cols: 120 },
+      }],
     }],
-  }],
+  }
 }
 
-describe('findClaudePanes', () => {
+describe('findClaudePanes (TTY-based)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAccess.mockRejectedValue(new Error('ENOENT') as never)
   })
 
-  it('returns empty array when no sessions exist', async () => {
+  it('returns empty array when the adapter reports no panes', async () => {
     const adapter = makeAdapter([])
     const result = await findClaudePanes(adapter)
     expect(result).toEqual([])
+    expect(mockExeca).not.toHaveBeenCalled()
   })
 
   it('returns empty array when ps fails', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
-    // ps call fails
+    const adapter = makeAdapter([sessionWithPane('dev', 'tmux:dev:@0:%0')], vi.fn().mockResolvedValue('ttys001'))
     mockExeca.mockRejectedValueOnce(new Error('ps failed') as never)
     const result = await findClaudePanes(adapter)
     expect(result).toEqual([])
   })
 
-  it('returns empty array when no Claude processes found in ps output', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
-    mockExeca.mockResolvedValueOnce({ stdout: '  200  100 /bin/zsh\n  201  200 vim main.ts' } as never)
+  it('returns empty array when no Claude procs appear in ps output', async () => {
+    const adapter = makeAdapter([sessionWithPane('dev', 'tmux:dev:@0:%0')], vi.fn().mockResolvedValue('ttys001'))
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  200 ttys001 /bin/zsh\n  201 ttys001 vim main.ts',
+    } as never)
     const result = await findClaudePanes(adapter)
     expect(result).toEqual([])
   })
 
-  it('finds Claude pane via --session-id in ps output and ancestor walk', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
-    // ps output: shell PID 100, node PID 200 (child of 100), with --session-id
+  it('matches Claude proc to pane by TTY via --session-id', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
     mockExeca.mockResolvedValueOnce({
-      stdout: [
-        '  100    1 /bin/zsh',
-        '  200  100 node /usr/local/bin/claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      ].join('\n'),
+      stdout: '  200 ttys001 node /usr/local/bin/claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     } as never)
     // lsof for CWD
     mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/home/user/project' } as never)
-    // access check for JSONL file will fail (file doesn't exist)
 
     const result = await findClaudePanes(adapter)
     expect(result).toHaveLength(1)
@@ -87,15 +104,16 @@ describe('findClaudePanes', () => {
     expect(result[0]!.sessionName).toBe('dev')
     expect(result[0]!.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
     expect(result[0]!.cwd).toBe('/home/user/project')
+    expect(result[0]!.jsonlPath).toBeNull() // access mocked to reject
   })
 
-  it('finds Claude pane via --resume flag', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
+  it('matches via --resume flag', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
     mockExeca.mockResolvedValueOnce({
-      stdout: [
-        '  100    1 /bin/zsh',
-        '  200  100 node /usr/local/bin/claude --resume aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      ].join('\n'),
+      stdout: '  200 ttys001 node claude --resume aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     } as never)
     mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/tmp' } as never)
 
@@ -104,27 +122,62 @@ describe('findClaudePanes', () => {
     expect(result[0]!.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
   })
 
-  it('skips Claude process when ancestor walk does not reach a known pane shell', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
-    // Claude process PID 999 with parent 998 — neither is the pane shell (100)
+  it('sets jsonlPath when the file exists on disk', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
     mockExeca.mockResolvedValueOnce({
-      stdout: [
-        '  100    1 /bin/zsh',
-        '  998    1 /bin/bash',
-        '  999  998 node /usr/local/bin/claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      ].join('\n'),
+      stdout: '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/home/user/project' } as never)
+    mockAccess.mockResolvedValueOnce(undefined as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.jsonlPath).toMatch(/\.claude\/projects\/-home-user-project\/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\.jsonl$/)
+  })
+
+  it('drops Claude proc whose TTY does not map to any known pane', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
+    // proc TTY ttys999 does not match ttys001
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  999 ttys999 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     } as never)
 
     const result = await findClaudePanes(adapter)
     expect(result).toEqual([])
   })
 
-  it('returns null cwd when lsof fails', async () => {
-    const adapter = makeAdapter([mockSession], vi.fn().mockResolvedValue(100))
+  it('skips Claude procs without a TTY (daemonised "??")', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
     mockExeca.mockResolvedValueOnce({
-      stdout: '  100    1 /bin/zsh\n  200  100 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      stdout: [
+        '  501 ?? node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        '  200 ttys001 node claude --resume bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ].join('\n'),
     } as never)
-    // lsof fails
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/tmp' } as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.sessionId).toBe('bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee')
+  })
+
+  it('returns null cwd when lsof fails', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    } as never)
     mockExeca.mockRejectedValueOnce(new Error('lsof failed') as never)
 
     const result = await findClaudePanes(adapter)
@@ -133,43 +186,113 @@ describe('findClaudePanes', () => {
     expect(result[0]!.jsonlPath).toBeNull()
   })
 
-  it('propagates pane title from adapter into ClaudePane.paneTitle', async () => {
-    const sessionWithTitle: Session = {
-      id: '$0',
-      name: 'Squirrel',
-      windows: [{
-        id: '@0',
-        name: 'main',
-        panes: [{
-          id: 'cmux:workspace:7:surface:12',
-          index: 0,
-          active: true,
-          command: '✳ Address PR comments',
-          title: '✳ Address PR comments',
-          dimensions: { rows: 40, cols: 120 },
-        }],
-      }],
-    }
-    const adapter = makeAdapter([sessionWithTitle], vi.fn().mockResolvedValue(100))
+  it('returns null cwd when lsof output has no n-line', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
     mockExeca.mockResolvedValueOnce({
-      stdout: '  100    1 /bin/zsh\n  200  100 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      stdout: '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200' } as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.cwd).toBeNull()
+  })
+
+  it('propagates pane title from adapter', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('Squirrel', 'cmux:workspace:7:surface:12', '✳ Address PR comments')],
+      vi.fn().mockResolvedValue('ttys007'),
+    )
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  200 ttys007 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/home/user/project' } as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result[0]!.paneTitle).toBe('✳ Address PR comments')
+  })
+
+  it('returns empty array when adapter has no getPaneTty support', async () => {
+    const adapter = makeAdapter([sessionWithPane('dev', 'tmux:dev:@0:%0')]) // no getPaneTty
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    } as never)
+    const result = await findClaudePanes(adapter)
+    expect(result).toEqual([])
+  })
+
+  it('deduplicates Claude procs that share a TTY (first wins)', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
+    mockExeca.mockResolvedValueOnce({
+      stdout: [
+        '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        '  201 ttys001 node claude --session-id bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ].join('\n'),
     } as never)
     mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/home/user/project' } as never)
 
     const result = await findClaudePanes(adapter)
     expect(result).toHaveLength(1)
-    expect(result[0]!.sessionName).toBe('Squirrel')
-    expect(result[0]!.paneTitle).toBe('✳ Address PR comments')
+    expect(result[0]!.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
   })
 
-  it('returns null when getPanePid is not available', async () => {
-    const adapter = makeAdapter([mockSession]) // no getPanePid
+  it('handles multiple panes with independent TTYs', async () => {
+    const twoSessions: Session[] = [
+      sessionWithPane('dev', 'tmux:dev:@0:%0'),
+      sessionWithPane('work', 'tmux:work:@0:%0'),
+    ]
+    const getPaneTty = vi.fn(async (id: string) =>
+      id === 'tmux:dev:@0:%0' ? 'ttys001' : 'ttys002',
+    )
+    const adapter = makeAdapter(twoSessions, getPaneTty)
     mockExeca.mockResolvedValueOnce({
-      stdout: '  200  100 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      stdout: [
+        '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        '  300 ttys002 node claude --resume bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ].join('\n'),
+    } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/a' } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p300\nn/b' } as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.sessionName).sort()).toEqual(['dev', 'work'])
+  })
+
+  it('skips panes where getPaneTty returns null', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue(null),
+    )
+    mockExeca.mockResolvedValueOnce({
+      stdout: '  200 ttys001 node claude --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     } as never)
 
     const result = await findClaudePanes(adapter)
-    // No shell PIDs known, so ancestor walk fails
     expect(result).toEqual([])
+  })
+
+  it('ignores lines with invalid PIDs', async () => {
+    const adapter = makeAdapter(
+      [sessionWithPane('dev', 'tmux:dev:@0:%0')],
+      vi.fn().mockResolvedValue('ttys001'),
+    )
+    mockExeca.mockResolvedValueOnce({
+      stdout: [
+        'HEADER ttys001 --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        '  200 ttys001 node claude --session-id bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ].join('\n'),
+    } as never)
+    mockExeca.mockResolvedValueOnce({ stdout: 'p200\nn/tmp' } as never)
+
+    const result = await findClaudePanes(adapter)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.sessionId).toBe('bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee')
   })
 })

--- a/packages/daemon/src/transcript/claude-finder.ts
+++ b/packages/daemon/src/transcript/claude-finder.ts
@@ -19,73 +19,55 @@ interface PaneEntry {
   paneId: string
   sessionName: string
   paneTitle?: string
-  shellPid: number | null
+  tty: string | null
+}
+
+interface ClaudeProc {
+  pid: number
+  sessionId: string
+  tty: string
 }
 
 /**
  * Find all terminal panes that have an active Claude process running in them.
  *
- * Strategy 1 (primary): scan `ps` for `--session-id` args, then walk each
- * Claude process's ancestor chain up to a known pane shell PID.
- *
- * Strategy 2 (fallback): scan recently-modified JSONL files and match their
- * encoded CWD against pane shell CWDs.
+ * Strategy: match `ps` Claude processes to panes by TTY. A TTY device is
+ * owned by exactly one pane, so this is 1:1 and immune to nested shell
+ * wrappings (cmux spawns two `-/bin/zsh` per surface, which used to break
+ * ancestor-PID matching).
  */
 export async function findClaudePanes(adapter: ITerminalAdapter): Promise<ClaudePane[]> {
-  // Collect all pane shell PIDs from the adapter
   const sessions = await adapter.listSessions()
 
   const paneEntries: PaneEntry[] = []
   for (const session of sessions) {
     for (const window of session.windows) {
       for (const pane of window.panes) {
-        const shellPid = adapter.getPanePid ? await adapter.getPanePid(pane.id) : null
-        paneEntries.push({ paneId: pane.id, sessionName: session.name, paneTitle: pane.title, shellPid })
+        const tty = adapter.getPaneTty ? await adapter.getPaneTty(pane.id) : null
+        paneEntries.push({ paneId: pane.id, sessionName: session.name, paneTitle: pane.title, tty })
       }
     }
   }
 
   if (paneEntries.length === 0) return []
 
-  // Single ps call — get pid, ppid, and full args for all processes
-  const psLines = await getPsOutput()
-  if (psLines.length === 0) return []
-
-  const parentOf = buildParentMap(psLines)
-
-  // Find Claude processes by scanning for --session-id in args
-  interface ClaudeProc {
-    pid: number
-    sessionId: string
-  }
-  const claudeProcs: ClaudeProc[] = []
-  for (const line of psLines) {
-    const sessionMatch = line.match(/--session-id\s+([0-9a-f-]{36})/)
-    const resumeMatch = line.match(/--resume\s+([0-9a-f-]{36})/)
-    const sessionId = (sessionMatch ?? resumeMatch)?.[1]
-    if (!sessionId) continue
-    const pidStr = line.trim().split(/\s+/)[0]
-    const pid = parseInt(pidStr!, 10)
-    if (!isNaN(pid)) claudeProcs.push({ pid, sessionId })
-  }
-
+  const claudeProcs = await findClaudeProcesses()
   if (claudeProcs.length === 0) return []
 
-  // Build lookup: shell PID → pane entry
-  const shellPidToEntry = new Map<number, PaneEntry>()
+  // Index panes by TTY for O(1) lookup per Claude proc.
+  const ttyToPane = new Map<string, PaneEntry>()
   for (const entry of paneEntries) {
-    if (entry.shellPid !== null) shellPidToEntry.set(entry.shellPid, entry)
+    if (entry.tty) ttyToPane.set(entry.tty, entry)
   }
 
   const results: ClaudePane[] = []
   const matchedPaneIds = new Set<string>()
 
-  // Strategy 1: ancestor walk for each Claude process
   for (const proc of claudeProcs) {
-    const match = findAncestorPane(proc.pid, parentOf, shellPidToEntry)
-    if (!match || matchedPaneIds.has(match.paneId)) continue
+    const pane = ttyToPane.get(proc.tty)
+    if (!pane || matchedPaneIds.has(pane.paneId)) continue
+    matchedPaneIds.add(pane.paneId)
 
-    matchedPaneIds.add(match.paneId)
     const cwd = await getProcessCwd(proc.pid)
     const jsonlPath = cwd ? buildJsonlPath(cwd, proc.sessionId) : null
     let jsonlExists = false
@@ -94,9 +76,9 @@ export async function findClaudePanes(adapter: ITerminalAdapter): Promise<Claude
     }
 
     results.push({
-      paneId: match.paneId,
-      sessionName: match.sessionName,
-      paneTitle: match.paneTitle,
+      paneId: pane.paneId,
+      sessionName: pane.sessionName,
+      paneTitle: pane.paneTitle,
       sessionId: proc.sessionId,
       cwd,
       jsonlPath: jsonlExists ? jsonlPath : null,
@@ -108,45 +90,34 @@ export async function findClaudePanes(adapter: ITerminalAdapter): Promise<Claude
 
 // ---- Helpers -----------------------------------------------------------
 
-async function getPsOutput(): Promise<string[]> {
+/**
+ * Scan `ps` for processes with --session-id/--resume in argv, returning each
+ * with its TTY. Uses `ps -o tty=` (TTY short name like "ttys009") so the value
+ * matches what adapters return from getPaneTty.
+ */
+async function findClaudeProcesses(): Promise<ClaudeProc[]> {
+  let stdout: string
   try {
-    const { stdout } = await execa('ps', ['-ax', '-o', 'pid=,ppid=,args='])
-    return stdout.split('\n')
+    ({ stdout } = await execa('ps', ['-ax', '-o', 'pid=,tty=,args=']))
   } catch {
     return []
   }
-}
 
-/** Build child → parent PID map from ps output lines. */
-function buildParentMap(lines: string[]): Map<number, number> {
-  const parentOf = new Map<number, number>()
-  for (const line of lines) {
+  const procs: ClaudeProc[] = []
+  for (const line of stdout.split('\n')) {
+    const sessionMatch = line.match(/--session-id\s+([0-9a-f-]{36})/)
+    const resumeMatch = line.match(/--resume\s+([0-9a-f-]{36})/)
+    const sessionId = (sessionMatch ?? resumeMatch)?.[1]
+    if (!sessionId) continue
+
     const parts = line.trim().split(/\s+/)
-    if (parts.length < 2) continue
     const pid = parseInt(parts[0]!, 10)
-    const ppid = parseInt(parts[1]!, 10)
-    if (!isNaN(pid) && !isNaN(ppid)) parentOf.set(pid, ppid)
-  }
-  return parentOf
-}
+    const tty = parts[1]!
+    if (isNaN(pid) || !tty || tty === '??') continue
 
-/** Walk up the process tree from `pid` until a known pane shell PID is found. */
-function findAncestorPane(
-  pid: number,
-  parentOf: Map<number, number>,
-  shellPidToEntry: Map<number, PaneEntry>,
-): PaneEntry | null {
-  let current = pid
-  const visited = new Set<number>()
-  while (current > 1 && !visited.has(current)) {
-    visited.add(current)
-    const entry = shellPidToEntry.get(current)
-    if (entry) return entry
-    const parent = parentOf.get(current)
-    if (!parent) break
-    current = parent
+    procs.push({ pid, sessionId, tty })
   }
-  return null
+  return procs
 }
 
 async function getProcessCwd(pid: number): Promise<string | null> {
@@ -163,4 +134,3 @@ function buildJsonlPath(cwd: string, sessionId: string): string {
   const encoded = cwd.replace(/\//g, '-')
   return join(homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`)
 }
-


### PR DESCRIPTION
The previous ancestor-PID walk failed when cmux wraps each surface shell in two nested `-/bin/zsh` login shells (the adapter would pick one shell PID while the Claude process's PPID was the other), silently dropping ~30% of active sessions from `list`.

Switch to TTY-based matching: each terminal TTY belongs to exactly one pane, and `ps -o tty=` gives us a direct 1:1 join with no ancestor walk. Add `getPaneTty` to the adapter interface, implement on cmux (via the existing `cmux tree` tty= parse) and tmux (via `#{pane_tty}`).

Unit tests: 100% coverage on claude-finder.ts (statements, branches, functions, lines). Added getPaneTty + getPanePid tests for both cmux and tmux adapters. 368 tests pass.